### PR TITLE
Reset player button on song end

### DIFF
--- a/templates/static/js/player.js
+++ b/templates/static/js/player.js
@@ -39,4 +39,8 @@ function make_player () {
       }
     }
   });
+
+  $(player).on('ended', function () {
+    $('.play-button').attr('src', play_src);
+  });
 }


### PR DESCRIPTION
The player button was staying in the playing state (a stop icon) when the playing song ended. This patch reverts it to its initial state (a play icon) when a song ends.

@KatamariJr Could you test this locally? I was only able to test it on the live site in DevTools since I no longer have all of the data required to build the site myself.