### PR TITLE
Set explicit data types for sortable table columns

### DIFF
--- a/templates/artist.html
+++ b/templates/artist.html
@@ -13,11 +13,11 @@
     <table class="table" data-sortable>
       <thead>
         <tr>
-          <th>Play</th>
-          <th data-sorted="true" data-sorted-direction="ascending">Name</th>
-          <th>Game(s)</th>
-          <th>Duel</th>
-          <th>Rank</th>
+          <th data-sortable="false">Play</th>
+          <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">Name</th>
+          <th data-sortable-type="alpha">Game(s)</th>
+          <th data-sortable-type="alpha">Duel</th>
+          <th data-sortable-type="numeric">Rank</th>
         </tr>
       </thead>
       <tbody>
@@ -46,12 +46,12 @@
     <table class="table" data-sortable>
       <thead>
         <tr>
-          <th>Play</th>
-          <th data-sorted="true" data-sorted-direction="ascending">Name</th>
-          <th>Game(s)</th>
-          <th>Other Artist(s)</th>
-          <th>Duel</th>
-          <th>Rank</th>
+          <th data-sortable="false">Play</th>
+          <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">Name</th>
+          <th data-sortable-type="alpha">Game(s)</th>
+          <th data-sortable-type="alpha">Other Artist(s)</th>
+          <th data-sortable-type="alpha">Duel</th>
+          <th data-sortable-type="numeric">Rank</th>
         </tr>
       </thead>
       <tbody>

--- a/templates/artists.html
+++ b/templates/artists.html
@@ -15,13 +15,13 @@
   <table class="table" data-sortable>
     <thead>
       <tr>
-        <th data-sorted="true" data-sorted-direction="ascending">
+        <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">
           Name {{ filter_input() }}
         </th>
         <th>♫</th>
-        <th class="gold">&bull;</th>
-        <th class="silver">&bull;</th>
-        <th class="bronze">&bull;</th>
+        <th class="gold" data-sortable-type="numeric">&bull;</th>
+        <th class="silver" data-sortable-type="numeric">&bull;</th>
+        <th class="bronze" data-sortable-type="numeric">&bull;</th>
       </tr>
     </thead>
     <tbody>

--- a/templates/duel.html
+++ b/templates/duel.html
@@ -100,11 +100,11 @@
     <table class="table" data-sortable>
       <thead>
         <tr>
-          <th>Play</th>
-          <th data-sorted="true" data-sorted-direction="ascending">Rank</th>
-          <th>Song</th>
-          <th>Artist(s)</th>
-          <th>Game(s)</th>
+          <th data-sortable="false">Play</th>
+          <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="numeric">Rank</th>
+          <th data-sortable-type="alpha">Song</th>
+          <th data-sortable-type="alpha">Artist(s)</th>
+          <th data-sortable-type="alpha">Game(s)</th>
         </tr>
       </thead>
       <tbody>

--- a/templates/duels.html
+++ b/templates/duels.html
@@ -43,9 +43,9 @@
       <table class="table" data-sortable>
         <thead>
           <tr>
-            <th width="47%" data-sorted="true" data-sorted-direction="descending">Month</th>
-            <th width="48%">Theme</th>
-            <th width="5%">♫</th>
+            <th width="47%" data-sorted="true" data-sorted-direction="descending" data-sortable-type="alpha">Month</th>
+            <th width="48%" data-sortable-type="alpha">Theme</th>
+            <th width="5%" data-sortable-type="numeric">♫</th>
           </tr>
         </thead>
         <tbody>

--- a/templates/game.html
+++ b/templates/game.html
@@ -13,11 +13,11 @@
     <table class="table" data-sortable>
       <thead>
         <tr>
-          <th>Play</th>
-          <th data-sorted="true" data-sorted-direction="ascending">Name</th>
-          <th>Artist(s)</th>
-          <th>Duel</th>
-          <th>Rank</th>
+          <th data-sortable="false">Play</th>
+          <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">Name</th>
+          <th data-sortable-type="alpha">Artist(s)</th>
+          <th data-sortable-type="alpha">Duel</th>
+          <th data-sortable-type="numeric">Rank</th>
         </tr>
       </thead>
       <tbody>
@@ -46,12 +46,12 @@
     <table class="table" data-sortable>
       <thead>
         <tr>
-          <th>Play</th>
-          <th data-sorted="true" data-sorted-direction="ascending">Name</th>
-          <th>Artist(s)</th>
-          <th>Other Game(s)</th>
-          <th>Duel</th>
-          <th>Rank</th>
+          <th data-sortable="false">Play</th>
+          <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">Name</th>
+          <th data-sortable-type="alpha">Artist(s)</th>
+          <th data-sortable-type="alpha">Other Game(s)</th>
+          <th data-sortable-type="alpha">Duel</th>
+          <th data-sortable-type="numeric">Rank</th>
         </tr>
       </thead>
       <tbody>

--- a/templates/games.html
+++ b/templates/games.html
@@ -15,10 +15,10 @@
   <table class="table" data-sortable>
     <thead>
       <tr>
-        <th data-sorted="true" data-sorted-direction="ascending">
+        <th data-sorted="true" data-sorted-direction="ascending" data-sortable-type="alpha">
           Name {{ filter_input() }}
         </th>
-        <th>♫</th>
+        <th data-sortable-type="numeric">♫</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
`sortable.js` is pretty good at guessing data types for columns, but it can get confused by data that contains a number. This patch sets an explicit data type on every sortable table column on the site.

I also disabled sorting on columns that don't need it, like the play button column on song tables.

@KatamariJr Could you test this since I no longer have the data locally?